### PR TITLE
Add filtering by grouped roles

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,8 +18,12 @@ class PagesController < ApplicationController
   private
 
   def filtered_salaries
-    # turn query parameters into SQL string for querying
-    query = query_params.to_h[:query].map { |k, v| "#{k} = '#{v}'" }.join(' AND ')
+    query = if query_params.to_h[:query][:grouped_titles]
+              { job_title: query_params.to_h[:query][:grouped_titles] }
+            else
+              # turn query parameters into SQL string for querying
+              query_params.to_h[:query].map { |k, v| "#{k} = '#{v}'" }.join(' AND ')
+            end
     Salary.where(query)
   end
 
@@ -38,6 +42,6 @@ class PagesController < ApplicationController
   end
 
   def query_params
-    params.permit(query: %i[year job_title remote flex equity workweek overtime])
+    params.permit(query: [:year, :job_title, :remote, :flex, :equity, :workweek, :overtime, grouped_titles: []])
   end
 end

--- a/app/models/salary.rb
+++ b/app/models/salary.rb
@@ -15,12 +15,10 @@
 #  updated_at :datetime         not null
 #
 class Salary < ApplicationRecord
-  ROLES = [
-    'Backend Developer', 'Frontend Developer', 'Fullstack Developer', 'Product Manager',
-    'Project Manager', 'QA Engineer', 'UI/UX Designer',
-    'Support Engineer', 'Tech consultant',
-    'Data Scientist', 'Data Analyst', 'AI Engineer'
-  ].freeze
+  WEB_DEV_DEVELOPER_ROLES    = ['Backend Developer', 'Frontend Developer', 'Fullstack Developer'].freeze
+  WEB_DEV_NON_DEV_ROLES      = ['Product Manager', 'Project Manager', 'QA Engineer', 'UI/UX Designer', 'Support Engineer', 'Tech consultant'].freeze
+  DATA_SCIENCE_DEV_ROLES     = ['AI Engineer'].freeze
+  DATA_SCIENCE_NON_DEV_ROLES = ['Data Scientist', 'Data Analyst'].freeze
 
   enum remote: { none_or_limited_remote: 0, partial_remote: 1, fully_remote: 2 }
   enum flex:   { no_flexible_hours: 0, with_core_time: 1, full_flex: 2 }
@@ -29,4 +27,24 @@ class Salary < ApplicationRecord
   validates :year, numericality: { greater_than: 2016, less_than_or_equal_to: Time.zone.now.year }
   validates :amount, numericality: { greater_than: 2_000_000, message: 'Are you sure your yearly salary was so low?' }
   validates :overtime, :workweek, numericality: { allow_nil: true }
+
+  def self.all_roles
+    WEB_DEV_DEVELOPER_ROLES + WEB_DEV_NON_DEV_ROLES + DATA_SCIENCE_DEV_ROLES + DATA_SCIENCE_NON_DEV_ROLES
+  end
+
+  def self.web_dev_roles
+    WEB_DEV_DEVELOPER_ROLES + WEB_DEV_NON_DEV_ROLES
+  end
+
+  def self.data_science_roles
+    DATA_SCIENCE_DEV_ROLES + DATA_SCIENCE_NON_DEV_ROLES
+  end
+
+  def self.developer_roles
+    WEB_DEV_DEVELOPER_ROLES + DATA_SCIENCE_DEV_ROLES
+  end
+
+  def self.non_developer_roles
+    WEB_DEV_NON_DEV_ROLES + DATA_SCIENCE_NON_DEV_ROLES
+  end
 end

--- a/app/views/pages/home.html.slim
+++ b/app/views/pages/home.html.slim
@@ -8,12 +8,17 @@ p If you are an alumni we encourage you to anonymously #{link_to 'add your first
 p = link_to 'Questions about the salaries?', faq_path
 
 h3.mt-4 Salaries
-p.card-subtitle.text-muted.mb-2 #{@max_entries} entries out of a max of #{@max_respondents} LW Japan Alumni.
+p.card-subtitle.text-muted.mb-2 #{@max_entries} entries out of a max of #{@max_respondents} LW Japan Alumni. Displayed data from #{@salaries.length} entries.
 - if params[:query]
   = link_to 'Clear query', root_path
 .d-flex.justify-content-between
   p.salary-card Median salary: ¥#{number_with_delimiter(@median)}
   p.salary-card Average salary: ¥#{number_with_delimiter(@average)}
+h5 Filter salaries
+= link_to 'Web Dev roles', root_path(query: { grouped_titles: Salary.web_dev_roles }), class: 'btn btn-outline-primary m-2'
+= link_to 'Data Science roles', root_path(query: { grouped_titles: Salary.data_science_roles }), class: 'btn btn-outline-primary m-2'
+= link_to 'Developer roles', root_path(query: { grouped_titles: Salary.developer_roles }), class: 'btn btn-outline-primary m-2'
+= link_to 'Non-developer roles', root_path(query: { grouped_titles: Salary.non_developer_roles }), class: 'btn btn-outline-primary m-2'
 - if current_user
   table
     thead

--- a/app/views/salaries/new.html.slim
+++ b/app/views/salaries/new.html.slim
@@ -3,7 +3,7 @@ h1.my-3 Add a new salary
   .row
     .col-12.col-md = f.input :amount, label: 'Yearly salary', hint: 'Including bonuses and other monetizable benefits (conference budget, education budget, etc.)'
     .col-12.col-md = f.input :year, label: 'Graduation year'
-    .col-12.col-md = f.input :job_title, collection: Salary::ROLES, include_blank: false, selected: Salary::ROLES.sample
+    .col-12.col-md = f.input :job_title, collection: Salary.all_roles, include_blank: false, selected: Salary.all_roles.sample
   .mt-3
     h3 Help us make the analysis more precise
     p These replies are optional, but they help give more context


### PR DESCRIPTION
While there already exists the possibility to filter by individual roles,
sometimes we would like to see the average and median salaries for web
dev positions, data science positions or other combinations. This commit
adds these filtering options.
